### PR TITLE
[BUG] fix rendering issue on safari

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -30,18 +30,22 @@ body {
 }
 
 .upgrade-icon {
+  max-width: 23.2px;
   height: 24px;
   background-repeat: no-repeat;
   background-size: contain;
   font-size: 0;
 }
+
 .inactive-upgrade {
   background-image: url('./assets/UpgradeInactive.png');
   position: relative;
 }
+
 .active-upgrade {
   background-image: url('./assets/UpgradeActive.png');
 }
+
 .type-icon {
   width: 100%;
   height: 100%;
@@ -50,24 +54,31 @@ body {
   background-size: contain;
   display: inline-block;
 }
+
 .str-icon {
   background-image: url('./assets/STR.png');
 }
+
 .int-icon {
   background-image: url('./assets/INT.png');
 }
+
 .dex-icon {
   background-image: url('./assets/DEX.png');
 }
+
 .mnt-icon {
   background-image: url('./assets/MNT.png');
 }
+
 .sp-icon {
   background-image: url('./assets/SP.png');
 }
+
 .gp-icon {
   background-image: url('./assets/GP.png');
 }
+
 .team-icon {
   width: 100%;
   height: 100%;
@@ -76,18 +87,23 @@ body {
   background-size: contain;
   display: inline-block;
 }
+
 .team-pumas {
   background-image: url('./assets/teams/pumas.png');
 }
+
 .team-angels {
   background-image: url('./assets/teams/angels.png');
 }
+
 .team-rivercity {
   background-image: url('./assets/teams/rivercity.png');
 }
+
 .team-mystic-unicorns {
   background-image: url('./assets/teams/mystic-unicorns.png');
 }
+
 .team-zenonia-knights {
   background-image: url('./assets/teams/zenonia-knights.png');
 }
@@ -96,6 +112,7 @@ body {
   from {
     transform: rotate(0deg);
   }
+
   to {
     transform: rotate(360deg);
   }
@@ -120,6 +137,7 @@ body {
   0% {
     opacity: 0;
   }
+
   100% {
     opacity: 1;
   }
@@ -130,65 +148,80 @@ body {
     transform: scale(0.1, 0.1);
     opacity: 0;
   }
+
   50% {
     opacity: 1;
   }
+
   100% {
     transform: scale(1.2, 1.2);
     opacity: 0;
   }
 }
+
 @keyframes pulsate2 {
   0% {
     transform: scale(0.1, 0.1);
     opacity: 0;
   }
+
   25% {
     opacity: 1;
   }
+
   50% {
     transform: scale(1.2, 1.2);
     opacity: 0;
   }
+
   100% {
     transform: scale(1.2, 1.2);
     opacity: 0;
   }
 }
+
 @keyframes pulsate3 {
   0% {
     transform: scale(0.1, 0.1);
     opacity: 0;
   }
+
   16.66% {
     opacity: 1;
   }
+
   33.33% {
     transform: scale(1.2, 1.2);
     opacity: 0;
   }
+
   100% {
     transform: scale(1.2, 1.2);
     opacity: 0;
   }
 }
+
 @keyframes pulsate4 {
   0% {
     transform: scale(0.1, 0.1);
     opacity: 0;
   }
+
   12.5% {
     opacity: 1;
   }
+
   25% {
     transform: scale(1.2, 1.2);
     opacity: 0;
   }
+
   100% {
     transform: scale(1.2, 1.2);
     opacity: 0;
   }
 }
+
 /* @-webkit-keyframes pulsate {
   0% {
     -webkit-transform: scale(0.1, 0.1);


### PR DESCRIPTION
On the safari browsers and iOS devices there an issue where the upgrade icons are taking up too much space and don't fit in their borders. [The issue can be seen here](https://i.imgur.com/jj9e3kC.png) This sets a max width to the icons so they all fit within the page

This fixes issues on safari, but I can't test iOS until it's deployed as I don't have a firebase api key